### PR TITLE
remove unknown rollup input option breakOnWarning

### DIFF
--- a/actioncable/rollup.config.js
+++ b/actioncable/rollup.config.js
@@ -38,7 +38,6 @@ export default [
       format: "umd",
       name: "ActionCable"
     },
-    breakOnWarning: false,
     plugins: [
       resolve(),
       terser(terserOptions)


### PR DESCRIPTION
As seen in https://buildkite.com/rails/rails/builds/104749#018d92dc-79b9-42bc-9a8c-bbcf5681f9eb/1165-1176 breakOnWarning does not seem to be a valid option for Rollup. I cannot find in the documentation, and therefore I think it can safely be removed.

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
